### PR TITLE
Hard-coded navigation for order consistency

### DIFF
--- a/_includes/header.njk
+++ b/_includes/header.njk
@@ -2,9 +2,8 @@
     <h1 class="site-title"><a href="{{ '/' | url }}">{{ metadata.title }}</a></h1>
     <nav>
         <ul>
-            {%- for nav in collections.nav -%}
-            <li><a href="{{ nav.url | url }}">{{ nav.data.navtitle }}</a></li>
-            {%- endfor -%}
+            <li><a href="{{ '/blog/' | url }}">Blog</a></li>
+            <li><a href="{{ '/about/' | url }}">About</a></li>
         </ul>
     </nav>
 </header>


### PR DESCRIPTION
The output order for `About` and `Blog` appeared to be inconsistent, so this has been hard-coded for now until the layouts are refactored.