### PR TITLE
Added simple cache-busting random number generator to stylesheet link

### DIFF
--- a/_data/global.json
+++ b/_data/global.json
@@ -1,4 +1,4 @@
 {
   "site_title": "Zachary Todd",
-  "something": "something else"
+  "timestamp": "20200420"
 }

--- a/_includes/base.njk
+++ b/_includes/base.njk
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>{{ global.site_title }}</title>
-  <link rel="stylesheet" href="/css/site.css">
+  <link rel="stylesheet" href="/css/site.css?{{ [1,2,3,4,5,6,7,8,9,10] | random }}">
 </head>
 <body>
   {% include "partials/header.njk" %}

--- a/_includes/base.njk
+++ b/_includes/base.njk
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>{{ global.site_title }}</title>
-  <link rel="stylesheet" href="/css/site.css?{{ [1,2,3,4,5,6,7,8,9,10] | random }}">
+  <link rel="stylesheet" href="/css/site.css?{{ global.timestamp }}">
 </head>
 <body>
   {% include "partials/header.njk" %}


### PR DESCRIPTION
This PR adds a global data value called `timestamp`, which is appended to the end of the `site.css` stylesheet link. When Netlify rebuilds the site with a new `timestamp` value, this will provide cache-busting functionality so returning users will get any new styles.